### PR TITLE
Ramrecorder

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -40,12 +40,18 @@
 
 #include "logger.h"
 
-#define LOG_ERROR(...) if (Log::enabled(Log::ERROR_LEVEL)) Log::write(Log::ERROR_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define LOG_WARNING(...) if (Log::enabled(Log::WARNING_LEVEL)) Log::write(Log::WARNING_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define LOG_STATUS(...) if (Log::enabled(Log::STATUS_LEVEL)) Log::write(Log::STATUS_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define LOG_INFO(...) if (Log::enabled(Log::INFO_LEVEL)) Log::write(Log::INFO_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define LOG_VERBOSE(...) if (Log::enabled(Log::VERBOSE_LEVEL)) Log::write(Log::VERBOSE_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define LOG_DEBUG(...) if (Log::enabled(Log::DEBUG_LEVEL)) Log::write(Log::DEBUG_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
+// The following macro returns the number of parameters in a trace statement
+// (the minus 1 reflects the fact that the first argument in a trace
+// statement is the format string, so the number of parameters is one less than
+// this)
+#define TRC_NUMPARAMS(...)  ((sizeof((int[]){__VA_ARGS__})/sizeof(int)) - 1)
+
+#define LOG_ERROR(...) Log::ramTrace(__FILE__,__LINE__,TRC_NUMPARAMS(__VA_ARGS__),__VA_ARGS__); if (Log::enabled(Log::ERROR_LEVEL)) Log::write(Log::ERROR_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
+#define LOG_WARNING(...) Log::ramTrace(__FILE__,__LINE__,TRC_NUMPARAMS(__VA_ARGS__),__VA_ARGS__); if (Log::enabled(Log::WARNING_LEVEL)) Log::write(Log::WARNING_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
+#define LOG_STATUS(...) Log::ramTrace(__FILE__,__LINE__,TRC_NUMPARAMS(__VA_ARGS__),__VA_ARGS__); if (Log::enabled(Log::STATUS_LEVEL)) Log::write(Log::STATUS_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
+#define LOG_INFO(...) Log::ramTrace(__FILE__,__LINE__,TRC_NUMPARAMS(__VA_ARGS__),__VA_ARGS__); if (Log::enabled(Log::INFO_LEVEL)) Log::write(Log::INFO_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
+#define LOG_VERBOSE(...) Log::ramTrace(__FILE__,__LINE__,TRC_NUMPARAMS(__VA_ARGS__),__VA_ARGS__); if (Log::enabled(Log::VERBOSE_LEVEL)) Log::write(Log::VERBOSE_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
+#define LOG_DEBUG(...) Log::ramTrace(__FILE__,__LINE__,TRC_NUMPARAMS(__VA_ARGS__),__VA_ARGS__); if (Log::enabled(Log::DEBUG_LEVEL)) Log::write(Log::DEBUG_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
 #define LOG_BACKTRACE(...) Log::backtrace(__VA_ARGS__)
 #define LOG_COMMIT(...) Log::commit()
 
@@ -57,7 +63,6 @@
 #define TRC_DEBUG     LOG_ERROR
 #define TRC_BACKTRACE LOG_ERROR
 #define TRC_COMMIT    LOG_COMMIT
-
 
 namespace Log
 {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -35,10 +35,18 @@
  */
 
 
+#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <pthread.h>
+#include <sys/time.h>
+#include <time.h>
+
+// Define the "Warn unused return" macro (to be nothing) as this macro is
+// needed by printf.h and is apparently undefined under -O2 optimisation
+#define __wur
+#include <printf.h>
+
 #include <algorithm>
 #include <boost/format.hpp>
 #include "log.h"
@@ -48,7 +56,7 @@ const char* log_level[] = {"Error", "Warning", "Status", "Info", "Verbose", "Deb
 #define MAX_LOGLINE 8192
 #define RAM_BUFSIZE (1024 * 1024)
 
-// This macro gives the size of a trace entry in the RAM buffer for a given
+// This macro gives the size of a trace entry in the RAM trace buffer for a given
 // number of parameters.
 //
 // In principle, we should worry about whether adjacent trace entries are
@@ -58,17 +66,16 @@ const char* log_level[] = {"Error", "Warning", "Status", "Info", "Verbose", "Deb
 // structure is the one with the greatest alignment restrictions (containing
 // the largest possible C basic types) there is no risk that the size of the
 // record is going to give us alignment problems of this type.
-#define RAM_SIZE(NUM_PARAMS) ((offsetof(TRC_RAMBUF_ENTRY, params)) + (NUM_PARAMS * TRC_RAMBUF_PARAM))
-#define RAM_ENTRY_SIZE(ENTRY) RAM_SIZE(Log::ram_trc_cache[ENTRY->trc_id - 1]->num_params)
+#define RAM_SIZE(NUM_PARAMS) (offsetof(TRC_RAMTRC_ENTRY, params) + (NUM_PARAMS * sizeof(TRC_RAMTRC_PARAM)))
 
 // The following structure is used to cache the parameters expected on a given
 // TRC_... call in the code.  Each entry is associated with a specific trace
-// ID which is written into each trace entry in the RAM buffer so that the
+// ID which is written into each trace entry in the RAM trace buffer so that the
 // format string, module and line number don't have to be reparsed and
-// rewritten into the RAM buffer for every trace call.
+// rewritten into the RAM trace buffer for every trace call.
 //
 // The trace id is 1-based so that
-// -  Zero filling unused space at the end of the RAM buffer following a wrap
+// -  Zero filling unused space at the end of the RAM trace buffer following a wrap
 //    means that such space can be easily identified as not containing a
 //    a valid trace entry
 // -  The calling code (see TRC_RAMTRACE in log.h) can safely treat a trc_id
@@ -79,7 +86,9 @@ typedef struct
   const char *module;
   const char *fmt;
   int         num_params;
+  int         entry_size;
   int         param_types[1];
+
 } TRC_RAMTRC_CACHE;
 
 // The following structure is a union of basic types that can be used to
@@ -88,18 +97,25 @@ typedef struct
 // The decoder uses the trace cache to determine how to interpret each value.
 typedef union
 {
-  char c;
   int i;
-  short s;
   long l;
   long long ll;
-  float f;
   double d;
   long double ld;
   void *p;
-} TRC_RAMBUF_PARAM;
 
-// The following structure defines an entry in the cycle RAM trace buffer
+} TRC_RAMTRC_PARAM;
+
+// The following structure defines an entry in the cyclic RAM trace buffer.
+// The number of params structures in any given entry is variable, so the
+// size of any given entry in the RAM trace buffer is not sizeof(TRC_RAMTRC_ENTRY),
+// but (offsetof(TRC_RAMTRC_ENTRY,params) + <number of parameters> *
+// sizeof(TRC_RAMTRC_PARAM)).
+//
+// There is special handling for those trace entries which just consist of a
+// single string passed by value.  These are indicated by having no format
+// string in the cache of trace calls (and a cached entry size of -1, as the
+// entry size is variable from instance to instance).
 //
 // @@@ Note that this implementation is a bit wasteful on space, as each entry
 // in params is 128 bits long (the size of a long long or long double),
@@ -113,9 +129,11 @@ typedef struct
 {
   pthread_t        thread;
   int              trc_id;
-  TRC_RAMBUF_PARAM params[1];
+  struct timeval   time;
+  int              entry_size;
+  TRC_RAMTRC_PARAM params[1];
 
-} TRC_RAMBUF_ENTRY;
+} TRC_RAMTRC_ENTRY;
 
 namespace Log
 {
@@ -124,11 +142,11 @@ namespace Log
   static pthread_mutex_t serialization_lock = PTHREAD_MUTEX_INITIALIZER;
   int loggingLevel = 4;
 
-  // RAM buffer and associated static parameters.  The RAM buffer consists of
-  // an area of memory (of arbitrary size) to which structures of type
-  // TRC_RAMBUF_ENTRY are written (these structures being of variable size
+  // RAM trace buffer and associated static parameters.  The RAM trace buffer
+  // consists of an area of memory (of arbitrary size) to which structures of type
+  // TRC_RAMTRC_ENTRY are written (these structures being of variable size
   // depending on the number of arguments represented by the entry).  Note
-  // that the buffer is deliberately unioned with a TRC_RAMBUF_ENTRY to ensure
+  // that the buffer is deliberately unioned with a TRC_RAMTRC_ENTRY to ensure
   // that it is correctly aligned.
   //
   // ram_next_slot points to the next available slot in the buffer (which might
@@ -140,19 +158,22 @@ namespace Log
   // Special care needs to be taken when wrapping (i.e. when the next record to
   // be written won't fit in the buffer).  We need to make sure that any
   // existing valid log data at the end of the buffer that we're having to skip
-  // over gets blatted to zero so that the dump tool doesn't regard the
+  // over gets blatted to zero so that the decode routine doesn't regard the
   // skipped bit as containing valid log data and spuriously dump rubbish.  As
-  // module cannot be validly NULL, just checking whether this field is NULL
+  // trc_id cannot be validly 0, just checking whether this field is 0
   // is enough to tell the dumper that its reached the end of the buffer
   // and needs to wrap back to the start.
   static union
   {
     char buf[RAM_BUFSIZE];
-    TRC_RAMBUF_ENTRY align;
-  } ram_buffer = 0;
+    TRC_RAMTRC_ENTRY align;
+  } ram_buffer = {{0}};
+
   static pthread_mutex_t ram_lock = PTHREAD_MUTEX_INITIALIZER;
-  static TRC_RAMBUF_ENTRY* ram_next_slot = &ram_buffer.align;
-  static TRC_RAMBUF_ENTRY* ram_head_slot = NULL;
+  pthread_mutex_t trc_ram_trc_cache_lock = PTHREAD_MUTEX_INITIALIZER;
+  static TRC_RAMTRC_ENTRY* ram_next_slot = &ram_buffer.align;
+
+  static TRC_RAMTRC_ENTRY* ram_head_slot = NULL;
 
   // The trace cache is an inventory of all the trace calls in the code,
   // built up dynamically as trace calls are made.  It avoids the need to
@@ -164,17 +185,140 @@ namespace Log
   static int ram_trc_cache_len = 0;
 }
 
-// Fast RAM buffer write routine
-void LOG::ramTrace(int trc_id, char *fmt, ...)
+// Trace call cache routine.  This function caches the details of format
+// string, file and line number and expected parameters.  The caller (an
+// instance of the TRC_RAMTRACE macro) stores the returned ID - in actuality a
+// 1-based index into an array of TRC_RAMTRC_CACHE structures - the first
+// time that path through the code is executed (in a static int) and then calls
+// into ramTrace below to make the RAM trace entry itself.  Subsequently the
+// same trace ID can be passed directly to ramTrace for maximally efficient
+// tracing of the call instance and the parameters passed.
+int Log::ramCacheTrcCall(const char *module, int lineno, const char*fmt, ...)
+{
+  int trc_id;
+
+  // Lock access to the RAM trace buffer.  We can't allow any ram tracing to take
+  // place while we fiddle with the cache as ram_trc_cache might change under
+  // the realloc call.
+  pthread_mutex_lock(&Log::ram_lock);
+
+  // Realloc (or allocate, if not yet allocated) the RAM trace cache
+  Log::ram_trc_cache_len++;
+  Log::ram_trc_cache = (TRC_RAMTRC_CACHE **)realloc(Log::ram_trc_cache, sizeof(TRC_RAMTRC_CACHE*) * Log::ram_trc_cache_len);
+
+  // Release the ram trace buffer lock.  In principle, this will release any other
+  // threads waiting to make trace calls, though in practise most of them will
+  // be blocked on the trc_ram_trc_cache_lock lock anyway.  Note that any
+  // simultaneous initial calls to this particular TRC_RAMTRACE call WILL
+  // be waiting on trc_ram_trc_cache_lock until the first has successfully
+  // filled the cache slot, so won't e.g. end up referencing the cache slot
+  // before its been initialised.
+  pthread_mutex_unlock(&Log::ram_lock);
+
+  // The trace ID we are going to return is simply the current value of the
+  // cache size (since its a 1-based index)
+  trc_id = Log::ram_trc_cache_len;
+
+  // Firstly, determine whether the format string is just "%s".  If so, then
+  // the intention is clearly to trace out a string that has already been
+  // formatted, and, since we normally store the pointer to any string
+  // parameter rather than the string itself (and therefore will be lucky if
+  // the string is still valid at dump time), we would normally not get any
+  // useful info from such a trace.  Therefore, for "%s" logs only, we store
+  // the string data by value rather than reference
+  size_t num_params;
+  int entry_size;
+  TRC_RAMTRC_CACHE *cache_ent;
+
+  if (strcmp(fmt, "%s") == 0)
+  {
+    // Allocate an "empty" cache structure (no params)
+    cache_ent = (TRC_RAMTRC_CACHE *)malloc(offsetof(TRC_RAMTRC_CACHE, param_types));
+
+    // Leave the format blank to indicate that no formatting is to be done
+    cache_ent->fmt = NULL;
+    num_params = 0;
+
+    // Set entry size to -1 to indicate that this parameter is not used (the
+    // size of an instance of this log cannot be known in advance)
+    entry_size = -1;
+  }
+  else
+  {
+    // Determine how many parameters to allow for using the parse_printf_format
+    // function.
+    num_params = parse_printf_format(fmt, 0, NULL);
+    entry_size = RAM_SIZE(num_params);
+
+    // Get sufficient memory for the cache entry using the ANSI standard
+    // algorithm for determining variable structure lengths
+    cache_ent = (TRC_RAMTRC_CACHE *)malloc(offsetof(TRC_RAMTRC_CACHE, param_types) + (num_params * sizeof(int)));
+
+    // Save the format string
+    cache_ent->fmt = fmt;
+
+    // Call the parse function again, this time allowing enough space for the
+    // parameter types to be written out.
+    parse_printf_format(fmt, num_params, cache_ent->param_types);
+  }
+
+  // Save the cache entry at the trace ID offset
+  Log::ram_trc_cache[trc_id - 1] = cache_ent;
+
+  // Fill in the rest of the entry
+  cache_ent->num_params = num_params;
+  cache_ent->line_number = lineno;
+
+  // Strip off any path header from the module
+  const char *nopath = strrchr(module, '/');
+  if (nopath != NULL)
+  {
+    cache_ent->module = nopath + 1;
+  }
+  else
+  {
+    cache_ent->module = module;
+  }
+
+  cache_ent->entry_size = entry_size;
+
+  return(trc_id);
+}
+
+// Fast RAM trace buffer write routine
+void Log::ramTrace(int trc_id, const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
 
-  // Lock access to the RAM buffer
-
+  // Lock access to the RAM trace buffer
   pthread_mutex_lock(&Log::ram_lock);
 
-  int entry_size = RAM_SIZE(num_params);
+  // Determine the entry size by looking at the cached trace object
+  TRC_RAMTRC_CACHE *this_cache = Log::ram_trc_cache[trc_id - 1];
+  int entry_size = this_cache->entry_size;
+  int string_length;
+  char *string_value = NULL;
+
+  // If entry size is -1, this implies that our argument list is a single
+  // string and we need to pass the argument by value rather than data
+  if (entry_size == -1)
+  {
+    // Get the string value and length
+    string_value = va_arg(args, char *);
+    string_length = strlen(string_value);
+
+    // Calculate the number of TRC_RAMTRC_PARAM structures we'll need in order
+    // to pass the string parameter by value.  To explain the slightly odd
+    // looking calculation below (which will be sensibly optimised by the
+    // compiler).
+    // -  We need enough space to store the string and its null terminator,
+    //    hence the "+1"
+    // -  We need to round UP to the number of TRC_RAMTRC_PARAMs that can
+    //    store this amount (hence the +(sizeof(TRC_RAMTRC_PARAM) - 1))
+    int num_params = ((string_length + 1 + (sizeof(TRC_RAMTRC_PARAM) - 1)) / sizeof(TRC_RAMTRC_PARAM));
+    entry_size = RAM_SIZE(num_params);
+  }
 
   // Find space in the buffer to write our trace entry into
   if (((char *)Log::ram_next_slot + entry_size) > (Log::ram_buffer.buf + RAM_BUFSIZE))
@@ -197,9 +341,10 @@ void LOG::ramTrace(int trc_id, char *fmt, ...)
 
   // If we have an oldest trace in the buffer (i.e., a "head" entry), bump this
   // along if we're about to overwrite it
-  while ((Log::ram_head_slot != NULL) && ((char *)Log::ram_next_slot + entry_size) > RAM_ENTRY_SIZE(Log::ram_head_slot))
+  while ((Log::ram_head_slot >= Log::ram_next_slot) &&
+         ((char *)Log::ram_head_slot < ((char *)Log::ram_next_slot + entry_size)))
   {
-    Log::ram_head_slot = (char *)Log::ram_head_slot + RAM_ENTRY_SIZE(Log::ram_head_slot);
+    Log::ram_head_slot = (TRC_RAMTRC_ENTRY *)((char *)Log::ram_head_slot + Log::ram_head_slot->entry_size);
 
     if ((((char *)Log::ram_head_slot + RAM_SIZE(0)) > (Log::ram_buffer.buf + RAM_BUFSIZE)) ||
         (Log::ram_head_slot->trc_id == 0))
@@ -212,260 +357,471 @@ void LOG::ramTrace(int trc_id, char *fmt, ...)
 
   // We now have a slot we can write our trace entry into and a head entry
   // which we are not about to overwrite.
-
-  // Save off a pointer to the slot and bump the next_slot pointer past it.
-  // Note that it doesn't matter if there isn't enough space in the buffer to
-  // write here - the next tracing thread will spot this and wrap it
-  // automatically.
-  TRC_RAMBUF_ENTRY *this_slot = Log::ram_next_slot;
-  Log::ram_next_slot = (char *)Log::ram_next_slot + entry_size;
-
-  // If we haven't got a "head" entry yet, this is it
-  if (Log::ram_head_slot == NULL)
-  {
-    Log::ram_head_slot = this_slot;
-  }
+  TRC_RAMTRC_ENTRY *this_slot = Log::ram_next_slot;
 
   // Fill in the fields in the slot
   this_slot->thread = pthread_self();
   this_slot->trc_id = trc_id;
+  this_slot->entry_size = entry_size;
+  gettimeofday(&this_slot->time, NULL);
 
   // Fill in the parameters, if any.  This is slightly involved, as we need to
   // be careful to pull the arguments off the stack according to their size,
   // which we determine from the trace cache entry.
-  TRC_RAMTRC_CACHE* this_cache = Log::ram_trc_cache[trc_id - 1];
-  int *type = this_cache->param_types;
-  TRC_RAMBUF_PARAM *value = this_slot->params;
-
-  for (int i = 0; i < this_cache->num_params; i++)
+  //
+  // If we have already cracked out a single string parameter, it means we
+  // aren't using pass by value and are just strcpying the string into the
+  // preallocated space
+  if (string_value != NULL)
   {
-    if (*type & PA_FLAG_PTR)
+    strcpy((char *)this_slot->params, string_value);
+  }
+  else
+  {
+    int *type = this_cache->param_types;
+    TRC_RAMTRC_PARAM *value = this_slot->params;
+
+    for (int i = 0; i < this_cache->num_params; i++)
     {
-      // This is a pointer and can be safely treated as a void *
-      value->p = va_arg(args, void *);
-    }
-    else
-    {
-      switch (*type & ~PA_FLAG_MASK)
+      if (*type & PA_FLAG_PTR)
       {
-      case PA_INT:
-        // use int, short, long or long long as appropriate.  Check for the
-        // int case first for performance thats the most likely type.
-
-        if (!(*type & (PA_FLAG_SHORT|PA_FLAG_LONG|PA_FLAG_LONG_LONG)))
-        {
-          value->i = va_arg(args, int);
-        }
-        else if (*type & PA_FLAG_SHORT)
-        {
-          value->s = va_arg(args, short);
-        }
-        else if (*type & PA_FLAG_LONG)
-        {
-          value->l = va_arg(args, long);
-        }
-        else
-        {
-          // Must be a long long
-          value->ll = va_arg(args, long long);
-        }
-        break;
-
-      case PA_CHAR:
-        value->c = va_arg(args, char);
-        break;
-
-      case PA_WCHAR:
-        value->w = va_arg(args, wide char);
-        break;
-
-      case PA_STRING:
-      case PA_WSTRING:
-      case PA_POINTER:
-        // These can all be treated as void *s
+        // This is a pointer and can be safely treated as a void *
         value->p = va_arg(args, void *);
-        break;
-
-      case PA_FLOAT:
-        value->f = va_arg(args, float);
-        break;
-
-      case PA_DOUBLE:
-        // Allow for a long double
-        if (*type & PA_FLAG_LONG_DOUBLE)
-        {
-          value->ld = va_arg(args, long double);
-        }
-        else
-        {
-          value->d = va_arg(args, double);
-        }
-        break;
-
-      default:
-        // Assume any other parameter is an int
-        value->i = va_arg(args, int);
-        break;
-      }
-    }
-
-    // Next type/value
-    type++;
-    value++;
-  }
-
-  // Release the ram buffer lock
-  pthread_mutex_unlock(&Log::ram_lock);
-
-  va_end(args);
-}
-
-// RAM buffer decode routine
-//
-// Note that this routine does not acquire locks.  It is intended to be run
-// via gdb against a core file and is hardened to allow for possible data
-// corruption
-//
-// If it is ever decided to run this live, expose a separate ram_lock wrapper
-// for this routine, but don't do call such a wrapper from a termination
-// signal handler or you may deadlock against a thread which has been
-// terminated.
-void LOG::ramDecode(FILE *output)
-{
-  // Start at the head of the buffer and print out eveything to the end.
-  if (Log::ram_head_slot == NULL)
-  {
-    fprintf("!!!RAM buffer is empty!!!\n");
-    return;
-  }
-
-  TRC_RAMBUF_ENTRY *this_entry = Log::ram_head_slot;
-
-  // We should be able to scan the buffer (expecting to wrap once) until we
-  // get to Log::ram_next_slot (effectively the tail pointer).  However, we
-  // need to take care we don't run off the end of the buffer or find ourselves
-  // wrapping more than once (as might happen if this buffer has been
-  // corrupted)
-  bool wrapped = false;
-  while ((this_entry != Log::ram_next_slot) && (this_entry <= (Log:ram_buffer.buf + RAM_BUFSIZE)))
-  {
-    // Print out the thread ID, module and line number
-    char *ptr = (char *)&this_entry->thread;
-
-    for (int i = 0; i++; i < sizeof(this_entry->thread))
-    {
-      fprintf(output, "%2.2X", char[i]);
-    }
-
-    TRC_RAMTRC_CACHE* this_cache = Log::ram_trc_cache[this_entry->trc_id - 1];
-    fprintf(output, " %s %d \"", this_cache->module, this_cache->line_number);
-
-    // Use the boost library to print the format out with the parameters we've
-    // saved in place (it would be simpler to build up a va_list and call
-    // vfprintf, but for the fact that va_lists can't be constructed unless
-    // the parameters are on the call stack).
-    boost::basic_format<char> fmt_trace(this_cache->fmt);
-
-    for (int i = 0; i++; i < this_cache->num_params)
-    {
-      if (this_cache->param_types[i] & PA_FLAG_PTR)
-      {
-        // This is a pointer
-        fmt_trace % this_entry->params[i].p;
       }
       else
       {
-        switch (this_cache->param_types[i] & ~PA_FLAG_MASK)
+        switch (*type & ~PA_FLAG_MASK)
         {
         case PA_INT:
-          // use int, short, long or long long as appropriate.
-          if (!(this_cache->param_types[i] & (PA_FLAG_SHORT|PA_FLAG_LONG|PA_FLAG_LONG_LONG)))
+          // use int, long or long long as appropriate.  Check for the
+          // int case first for performance thats the most likely type.
+          //
+          // shorts are passed as ints and you get annoying compiler warnings if
+          // you do "va_arg(args, short)", so ignore the PA_FLAG_SHORT flag.
+          if (!(*type & (PA_FLAG_LONG|PA_FLAG_LONG_LONG)))
           {
-            fmt_trace % this_entry->params[i].i;
+            value->i = va_arg(args, int);
           }
-          else if (this_cache->param_types[i] & PA_FLAG_SHORT)
+          else if (*type & PA_FLAG_LONG)
           {
-            fmt_trace % this_entry->params[i].s;
-          }
-          else if (this_cache->param_types[i] & PA_FLAG_LONG)
-          {
-            fmt_trace % this_entry->params[i].l;
+            value->l = va_arg(args, long);
           }
           else
           {
             // Must be a long long
-            fmt_trace % this_entry->params[i].ll;
+            value->ll = va_arg(args, long long);
           }
           break;
 
         case PA_CHAR:
-          fmt_trace % this_entry->params[i].c;
-          break;
-
         case PA_WCHAR:
-          fmt_trace % this_entry->params[i].w;
+          // chars and wide chars are passed as ints and you get annoying
+          // compiler warnings if you do "va_arg(args, char)", so treat as an
+          // integer.
+          value->i = va_arg(args, int);
           break;
 
         case PA_STRING:
         case PA_WSTRING:
         case PA_POINTER:
-          fmt_trace % this_entry->params[i].p;
+          // These can all be treated as void *s
+          value->p = va_arg(args, void *);
           break;
 
         case PA_FLOAT:
-          fmt_trace % this_entry->params[i].f;
+          // floats are passed as doubles and you get annoying compiler warnings
+          // if you do "va_arg(args, float)", so treat as a double.
+          value->d = va_arg(args, double);
           break;
 
         case PA_DOUBLE:
           // Allow for a long double
-          if (this_cache->param_types[i] & PA_FLAG_LONG_DOUBLE)
+          if (*type & PA_FLAG_LONG_DOUBLE)
           {
-            fmt_trace % this_entry->params[i].ld;
+            value->ld = va_arg(args, long double);
           }
           else
           {
-            fmt_trace % this_entry->params[i].d;
+            value->d = va_arg(args, double);
           }
           break;
 
         default:
           // Assume any other parameter is an int
-          fmt_trace % this_entry->params[i].i;
+          value->i = va_arg(args, int);
           break;
+        }
+      }
+
+      // Next type/value
+      type++;
+      value++;
+    }
+  }
+
+  // Bump the next_slot pointer past the trace entry we've just written.
+  // Note that it doesn't matter if there isn't enough space in the buffer to
+  // write here - the next tracing thread will spot this and wrap it
+  // automatically.
+  Log::ram_next_slot = (TRC_RAMTRC_ENTRY *)((char *)this_slot + entry_size);
+
+  // If we haven't got a "head" entry yet, set this up
+  if (Log::ram_head_slot == NULL)
+  {
+    Log::ram_head_slot = this_slot;
+  }
+
+  // Release the ram trace buffer lock
+  pthread_mutex_unlock(&Log::ram_lock);
+
+  va_end(args);
+}
+
+// RAM trace buffer decode routine
+//
+// Note that this routine does not acquire locks.  It is intended to be run
+// from termination signal handlers and is hardened to allow for possible data
+// corruption.
+//
+// If it is ever decided to run this live, expose a separate ram_lock wrapper
+// for this routine, but don't call such a wrapper from a termination
+// signal handler or you may deadlock against a thread which has been
+// terminated.
+//
+// Strings:  This routine satisfies %s format specifiers by printing the pointer
+// to the string rather than the original string data.  This is because, in
+// general, the string pointer will no longer be valid at the point at which
+// the trace buffer was dumped (and we deliberately trace string pointers by
+// pointer value rather than string contents for performance).  Note that
+// trace calls that use the format string "%s" are an exception.  Such calls
+// typically indicate that any already-formatted buffer is being logged, and
+// logging just the pointer to this format buffer tells us nothing.  Since the
+// performance hit of formatting the string has already been taken, the delta
+// of writing the string to the RAM trace buffer is outweighed by the diagnostic
+// benefits and so in this case (only) the string is written out in full (see
+// ramCacheTrcCall above for details).
+//
+// In case this proves to be too limiting, code for attempting to print string
+// contents is included (disabled) below.
+void Log::ramDecode(FILE *output)
+{
+  // Start at the head of the buffer and print out eveything to the end.
+  if (Log::ram_head_slot == NULL)
+  {
+    fprintf(output, "!!!RAM trace buffer is empty!!!\n");
+    return;
+  }
+
+  TRC_RAMTRC_ENTRY *this_entry = Log::ram_head_slot;
+
+  // We should be able to scan the buffer (expecting to wrap at most once) until
+  // we get to Log::ram_next_slot (effectively the tail pointer).  However, we
+  // need to take care we don't run off the end of the buffer or find ourselves
+  // wrapping more than once (as might happen if this buffer has been
+  // corrupted)
+  bool wrapped = false;
+  while ((this_entry != Log::ram_next_slot) && ((char *)this_entry <= (Log::ram_buffer.buf + RAM_BUFSIZE)))
+  {
+    // Print out the thread ID, module and line number
+    unsigned char *ptr = (unsigned char *)&this_entry->thread;
+
+    for (unsigned int i = 0; i < sizeof(this_entry->thread); i++)
+    {
+      fprintf(output, "%2.2X", ptr[i]);
+    }
+
+    // Emit the timestamp for the log and the module and line number
+    char hr_dateutc[64];
+    struct tm dateutc;
+
+    gmtime_r(&this_entry->time.tv_sec, &dateutc);
+    strftime(hr_dateutc, sizeof(hr_dateutc), "%d-%m-%Y %H:%M:%S", &dateutc);
+    TRC_RAMTRC_CACHE* this_cache = Log::ram_trc_cache[this_entry->trc_id - 1];
+
+    fprintf(output, " %s.%06ld UTC %s:%d: ", hr_dateutc, this_entry->time.tv_usec, this_cache->module, this_cache->line_number);
+
+    // Treat trace lines that have been passed by value (because they're already
+    // formatted) separately.  These are identified by having no format string.
+
+#if ATTEMPTING_TO_PRINT_STRING_CONTENTS
+    std::vector<void*> strings;
+#endif
+
+    if (this_cache->fmt == NULL)
+    {
+      // Just print out the string starting at the parameter structure
+      fprintf(output, "%s", (char *)this_entry->params);
+    }
+    else
+    {
+      // Use the boost library to print the format out with the parameters we've
+      // saved in place (it would be simpler to build up a va_list and call
+      // vfprintf, but for the fact that va_lists can't be constructed unless
+      // the parameters are on the call stack).
+      boost::basic_format<char> fmt_trace(this_cache->fmt);
+
+      // Unfortunately, the boost library does not support the precision marker
+      // '*' (e.g. "... %.*s ....") in format strings, which is a shame because
+      // if you pass in the integer parameter that specifies the string length
+      // (as returned by the parse_printf_format routine) boost goes
+      // "you've specified too many arguments" and bombs out.
+      //
+      // Therefore, we have to scan through the format string as we're adding
+      // parameters to the output object and, if we hit an integer, we have to
+      // determine whether its the precision argument and save it off.
+      //
+      // At the moment, we don't actually use the precision value (other than
+      // as a reminder that need to skip the "fmt_trace % this_entry->params[i].i;"
+      // for the parameter) as we don't print string contents - just the
+      // pointers to them.
+      const char *fmt_ptr = this_cache->fmt;
+      int precision = -1;
+
+      for (int i = 0; i < this_cache->num_params; i++)
+      {
+        fmt_ptr = strchr(fmt_ptr, '%');
+        // We need to skip escaped '%' characters
+        while ((fmt_ptr != NULL) && (memcmp(fmt_ptr, "%%", 2) == 0))
+        {
+          fmt_ptr = strchr(fmt_ptr + 2, '%');
+        }
+
+        if (fmt_ptr == NULL)
+        {
+          // Something's gone wrong.  Break out of the loop
+          fprintf(output, "Unexpectedly reached the end of the format specifiers \"%s\"", this_cache->fmt);
+          break;
+        }
+
+        bool got_pres = false;
+
+        if (precision == -1)
+        {
+          // Check whether this is going to be a precision specifier by looking
+          // at the current format specifier in the format string.
+          const char *fmt_end = strchr(fmt_ptr, ' ');
+          const char *pres_spec = strstr(fmt_ptr, ".*");
+
+          if ((pres_spec != NULL) &&
+              ((fmt_end == NULL) || (pres_spec < fmt_end)))
+          {
+            got_pres = true;
+          }
+        }
+
+        if ((precision == -1) && got_pres)
+        {
+          // We've found a "*" precision marker.  We must save this value
+          // and use it to format the following string/wide string
+          // appropriately
+          //
+          // Make sure this is an int (no flags).  If it isn't, something's gone
+          // wrong.
+          if (this_cache->param_types[i] != PA_INT)
+          {
+            fprintf(output, "Unexpectedly found field of type %x when was expecting a PA_INT in \"%s\"", this_cache->param_types[i], this_cache->fmt);
+            fmt_ptr = NULL;
+            break;
+          }
+
+          precision = this_entry->params[i].i;
+
+          if (precision < 0)
+          {
+            // Unexpected.  We must drop out here as otherwise we'll loop
+            // indefinitely
+            fmt_ptr = NULL;
+            fprintf(output, "Unexpectedly found negative precision value %d in \"%s\"", precision, this_cache->fmt);
+            break;
+          }
+
+          // Don't bump the format specifier.  We'll skip this branch next time
+          // round because precision will be set.
+        }
+        else
+        {
+          if (this_cache->param_types[i] & PA_FLAG_PTR)
+          {
+            // This is a pointer
+            fmt_trace % this_entry->params[i].p;
+          }
+          else
+          {
+#if ATTEMPTING_TO_PRINT_STRING_CONTENTS
+            char *str_ptr;
+            wchar_t *wstr_ptr;
+#endif
+
+            switch (this_cache->param_types[i] & ~PA_FLAG_MASK)
+            {
+            case PA_INT:
+              // use int, long or long long as appropriate.
+              if (!(this_cache->param_types[i] & (PA_FLAG_LONG|PA_FLAG_LONG_LONG)))
+              {
+                fmt_trace % this_entry->params[i].i;
+              }
+              else if (this_cache->param_types[i] & PA_FLAG_LONG)
+              {
+                fmt_trace % this_entry->params[i].l;
+              }
+              else
+              {
+                // Must be a long long
+                fmt_trace % this_entry->params[i].ll;
+              }
+              break;
+
+            case PA_CHAR:
+              fmt_trace % this_entry->params[i].i;
+              break;
+
+            case PA_WCHAR:
+              fmt_trace % this_entry->params[i].i;
+              break;
+
+            case PA_STRING:
+#if ATTEMPTING_TO_PRINT_STRING_CONTENTS
+              // If we have saved a precision value from the previous parameter,
+              // copy the string to a new buffer of the appropriate size
+              if (precision != -1)
+              {
+                str_ptr = new char[precision + 1];
+                strncpy(str_ptr, (const char *)this_entry->params[i].p, precision);
+                str_ptr[precision] = 0;
+              }
+              else
+              {
+                str_ptr = (char *)this_entry->params[i].p;
+              }
+
+              fmt_trace % str_ptr;
+
+              // Save the string pointer in a list.  The string we've just
+              // inserted might well be rubbish, as we only saved the pointer
+              // which could have been to data that was on the stack or was in
+              // heap space that has since been reallocated.  If that's the case
+              // the pointer itself might still have diagnostic value
+              strings.push_back(this_entry->params[i].p);
+#else
+              // We're not attempting to print string contents as they may be
+              // misleading.  Just trace out the string pointer
+              fmt_trace % this_entry->params[i].p;
+#endif
+              break;
+
+            case PA_WSTRING:
+#if ATTEMPTING_TO_PRINT_STRING_CONTENTS
+              // If we have saved a precision value from the previous parameter,
+              // copy the string to a new buffer of the appropriate size
+              if (precision != -1)
+              {
+                wstr_ptr = new wchar_t[precision + 1];
+                wcsncpy(wstr_ptr, (const wchar_t *)this_entry->params[i].p, precision);
+                wstr_ptr[precision] = 0;
+              }
+              else
+              {
+                wstr_ptr = (wchar_t *)this_entry->params[i].p;
+              }
+
+              fmt_trace % wstr_ptr;
+              strings.push_back(this_entry->params[i].p);
+#else
+              // We're not attempting to print string contents as they may be
+              // misleading.  Just trace out the string pointer
+              fmt_trace % this_entry->params[i].p;
+#endif
+              break;
+
+            case PA_POINTER:
+              fmt_trace % this_entry->params[i].p;
+              break;
+
+            case PA_FLOAT:
+              fmt_trace % this_entry->params[i].d;
+              break;
+
+            case PA_DOUBLE:
+              // Allow for a long double
+              if (this_cache->param_types[i] & PA_FLAG_LONG_DOUBLE)
+              {
+                fmt_trace % this_entry->params[i].ld;
+              }
+              else
+              {
+                fmt_trace % this_entry->params[i].d;
+              }
+              break;
+
+            default:
+              // Assume any other parameter is an int
+              fmt_trace % this_entry->params[i].i;
+              break;
+            }
+          }
+
+          // Bump the format pointer so that we look at the next format specifier
+          // (if any) and reset any precision value we might have parsed out
+          fmt_ptr++;
+          precision = -1;
+        }
+      }
+
+      // Write the formatted trace line out.  If we couldn't parse the format
+      // string, we've already traced the error
+      if (fmt_ptr != NULL)
+      {
+        try
+        {
+          fwrite(fmt_trace.str().c_str(), strlen(fmt_trace.str().c_str()), 1, output);
+        }
+        catch (...)
+        {
+          fprintf(output, "<corrupted trace>");
         }
       }
     }
 
-    // Write the formatted trace line out
-    try
+#if ATTEMPTING_TO_PRINT_STRING_CONTENTS
+    // If we had any strings, print their pointer values out as these will
+    // often be more useful than the string values themselves (which might
+    // have been overwritten).
+    if (!strings.empty())
     {
-      fprintf(output, fmt_trace.str().c_str());
-    }
-    catch (...)
-    {
-      fprintf(output, "<corrupted trace>");
-    }
+      fprintf(output, ":string pointers");
 
-    // Close the comments and LF terminate the output line
-    fprintf(output, "\"\n");
+      for (std::vector<void*>::iterator iter = strings.begin();
+           iter != strings.end();
+           ++iter)
+      {
+        fprintf(output, ",%p", *iter);
+      }
+    }
+#endif
+
+    // LF terminate the output line
+    fprintf(output, "\n");
 
     // Now find the next trace entry
-    this_entry += RAM_ENTRY_SIZE(this_entry);
+    this_entry = (TRC_RAMTRC_ENTRY *)((char *)this_entry + this_entry->entry_size);
 
     // Is it time to wrap?
-    if ((((char *)this_entry + RAM_SIZE(0)) > (Log::ram_buffer.buf + RAM_BUFSIZE)) ||
-        (this_entry->trc_id == 0))
+    if (this_entry != Log::ram_next_slot)
     {
-      // Too near the end of the RAM buffer.  It must be time to wrap
-      if (wrapped)
+      if ((((char *)this_entry + RAM_SIZE(0)) > (Log::ram_buffer.buf + RAM_BUFSIZE)) ||
+          (this_entry->trc_id == 0))
       {
-        // We've already wrapped.  The buffer must be corrupt
-        fprintf("!!!Already wrapped. RAM buffer is corrupt!!!\n");
-        return;
-      }
+        // Too near the end of the RAM trace buffer.  It must be time to wrap
+        if (wrapped)
+        {
+          // We've already wrapped.  The buffer must be corrupt
+          fprintf(output, "!!!Already wrapped. RAM trace buffer is corrupt!!!\n");
+          return;
+        }
 
-      wrapped = true;
-      this_entry = &Log::ram_buffer.align;
+        wrapped = true;
+        this_entry = &Log::ram_buffer.align;
+      }
     }
   }
 
@@ -473,7 +829,7 @@ void LOG::ramDecode(FILE *output)
   {
     // We ran off the end of the buffer rather than finding the tail.  Warn the
     // caller that the trace buffer is corrupted
-    fprintf("!!!Run off the end of the RAM buffer.  Trace corrupted!!!\n");
+    fprintf(output, "!!!Run off the end of the RAM trace buffer.  Trace corrupted!!!\n");
     return;
   }
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -47,14 +47,72 @@ const char* log_level[] = {"Error", "Warning", "Status", "Info", "Verbose", "Deb
 #define MAX_LOGLINE 8192
 #define RAM_BUFSIZE (1024 * 1024)
 
+// This macro gives the size of a trace entry in the RAM buffer for a given
+// number of parameters.
+//
+// In principle, we should worry about whether adjacent trace entries are
+// going to be aligned properly - in the worst case, we might get an alignment
+// exception if we attempt to point at a trace entry in the buffer that
+// starts, e.g., on an odd address.  Fortunately, the fact that the last entry in the
+// structure is the one with the greatest alignment restrictions (containing
+// the largest possible C basic types) there is no risk that the size of the
+// record is going to give us alignment problems of this type.
+#define RAM_SIZE(NUM_PARAMS) ((offsetof(TRC_RAMBUF_ENTRY, params)) + (NUM_PARAMS * TRC_RAMBUF_PARAM))
+#define RAM_ENTRY_SIZE(ENTRY) RAM_SIZE(Log::ram_trc_cache[ENTRY->trc_id - 1]->num_params)
+
+// The following structure is used to cache the parameters expected on a given
+// TRC_... call in the code.  Each entry is associated with a specific trace
+// ID which is written into each trace entry in the RAM buffer so that the
+// format string, module and line number don't have to be reparsed and
+// rewritten into the RAM buffer for every trace call.
+//
+// The trace id is 1-based so that
+// -  Zero filling unused space at the end of the RAM buffer following a wrap
+//    means that such space can be easily identified as not containing a
+//    a valid trace entry
+// -  The calling code (see TRC_RAMTRACE in log.h) can safely treat a trc_id
+//    value of zero as meaning "trace call not cached yet".
 typedef struct
 {
-  pthread_t   thread;
   int         line_number;
   const char *module;
   const char *fmt;
   int         num_params;
-  va_arg      params[1];
+  int         param_types[1];
+} TRC_RAMTRC_CACHE;
+
+// The following structure is a union of basic types that can be used to
+// store an basic type that can be passed to a printf call.  It is used by the
+// RAM trace code to store the parameter data passed on a given trace instance.
+// The decoder uses the trace cache to determine how to interpret each value.
+typedef union
+{
+  char c;
+  int i;
+  short s;
+  long l;
+  long long ll;
+  float f;
+  double d;
+  long double ld;
+  void *p;
+} TRC_RAMBUF_PARAM;
+
+// The following structure defines an entry in the cycle RAM trace buffer
+//
+// @@@ Note that this implementation is a bit wasteful on space, as each entry
+// in params is 128 bits long (the size of a long long or long double),
+// despite the fact that the vast majority of parameters are going to be 32-bit
+// ints.  Packing parameter data on byte boundaries would be an alternative
+// implementation that would be much more efficient in its use of space.
+// However, in order to avoid alignment issues, parameter values would need to
+// be memcpied into place which is far less performance-efficient for ints
+// than straightforward assignment. @@@
+typedef struct
+{
+  pthread_t        thread;
+  int              trc_id;
+  TRC_RAMBUF_PARAM params[1];
 
 } TRC_RAMBUF_ENTRY;
 
@@ -94,10 +152,19 @@ namespace Log
   static pthread_mutex_t ram_lock = PTHREAD_MUTEX_INITIALIZER;
   static TRC_RAMBUF_ENTRY* ram_next_slot = &ram_buffer.align;
   static TRC_RAMBUF_ENTRY* ram_head_slot = NULL;
+
+  // The trace cache is an inventory of all the trace calls in the code,
+  // built up dynamically as trace calls are made.  It avoids the need to
+  // duplicate the details of a given log call in the trace buffer or parse
+  // the format string every time that trace call is made.
+  //
+  // It is indexed by ("trace id" - 1).
+  static TRC_RAMTRC_CACHE** ram_trc_cache = NULL;
+  static int ram_trc_cache_len = 0;
 }
 
 // Fast RAM buffer write routine
-void LOG::ramTrace(const char *module, int line_number, int num_params, char *fmt, ...)
+void LOG::ramTrace(int trc_id, char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -108,13 +175,13 @@ void LOG::ramTrace(const char *module, int line_number, int num_params, char *fm
 
   int entry_size = RAM_SIZE(num_params);
 
-  // Find space in the buffer to write our log entry into
-  if (((char *)Log::ram_next_slot + entry_size) > (ram_buffer.buf + RAM_BUFSIZE))
+  // Find space in the buffer to write our trace entry into
+  if (((char *)Log::ram_next_slot + entry_size) > (Log::ram_buffer.buf + RAM_BUFSIZE))
   {
-    // The log isn't going to fit at the end of the buffer, so we need to wrap it.
+    // The trace isn't going to fit at the end of the buffer, so we need to wrap it.
     // Set any remaining space in the buffer to zero (so that it can't be accidentally
     // interpreted as good data).
-    memset((char *)Log::ram_next_slot, 0, RAM_BUFSIZE - ((char *)Log::ram_next_slot - ram_buffer.buf));
+    memset((char *)Log::ram_next_slot, 0, RAM_BUFSIZE - ((char *)Log::ram_next_slot - Log::ram_buffer.buf));
 
     // Check whether the head slot is in the space we have just destroyed (in which case this
     // needs to be reset to the start of the buffer).
@@ -127,14 +194,14 @@ void LOG::ramTrace(const char *module, int line_number, int num_params, char *fm
     Log::ram_next_slot = &Log::ram_buffer.align;
   }
 
-  // If we have an oldest log in the buffer (i.e., a "head" entry), bump this
+  // If we have an oldest trace in the buffer (i.e., a "head" entry), bump this
   // along if we're about to overwrite it
   while ((Log::ram_head_slot != NULL) && ((char *)Log::ram_next_slot + entry_size) > RAM_ENTRY_SIZE(Log::ram_head_slot))
   {
     Log::ram_head_slot = (char *)Log::ram_head_slot + RAM_ENTRY_SIZE(Log::ram_head_slot);
 
-    if ((((char *)Log::ram_head_slot + sizeof(TRC_RAMBUF_ENTRY)) > (ram_buffer.buf + RAM_BUFSIZE)) ||
-        (Log::ram_head_slot->module == NULL))
+    if ((((char *)Log::ram_head_slot + RAM_SIZE(0)) > (Log::ram_buffer.buf + RAM_BUFSIZE)) ||
+        (Log::ram_head_slot->trc_id == 0))
     {
       // Head slot no longer points to a valid thread entry.  Wrap it and stop looking
       Log::ram_head_slot = &Log::ram_buffer.align;
@@ -142,12 +209,12 @@ void LOG::ramTrace(const char *module, int line_number, int num_params, char *fm
     }
   }
 
-  // We now have a slot we can write our log entry into and a head entry
+  // We now have a slot we can write our trace entry into and a head entry
   // which we are not about to overwrite.
 
   // Save off a pointer to the slot and bump the next_slot pointer past it.
   // Note that it doesn't matter if there isn't enough space in the buffer to
-  // write here - the next logging thread will spot this and wrap it
+  // write here - the next tracing thread will spot this and wrap it
   // automatically.
   TRC_RAMBUF_ENTRY *this_slot = Log::ram_next_slot;
   Log::ram_next_slot = (char *)Log::ram_next_slot + entry_size;
@@ -160,21 +227,252 @@ void LOG::ramTrace(const char *module, int line_number, int num_params, char *fm
 
   // Fill in the fields in the slot
   this_slot->thread = pthread_self();
-  this_slot->module = module;
-  this_slot->line_number = line_number;
-  this_slot->fmt = fmt;
-  this_slot->num_params = num_params;
+  this_slot->trc_id = trc_id;
 
-  for (int i = 0; i < num_args; i++)
+  // Fill in the parameters, if any.  This is slightly involved, as we need to
+  // be careful to pull the arguments off the stack according to their size,
+  // which we determine from the trace cache entry.
+  TRC_RAMTRC_CACHE* this_cache = Log::ram_trc_cache[trc_id - 1];
+  int *type = this_cache->param_types;
+  TRC_RAMBUF_PARAM *value = this_slot->params;
+
+  for (int i = 0; i < this_cache->num_params; i++)
   {
-    this_slot->params[i] =
+    if (*type & PA_FLAG_PTR)
+    {
+      // This is a pointer and can be safely treated as a void *
+      value->p = va_arg(args, void *);
+    }
+    else
+    {
+      switch (*type & ~PA_FLAG_MASK)
+      {
+      case PA_INT:
+        // use int, short, long or long long as appropriate.  Check for the
+        // int case first for performance thats the most likely type.
+
+        if (!(*type & (PA_FLAG_SHORT|PA_FLAG_LONG|PA_FLAG_LONG_LONG)))
+        {
+          value->i = va_arg(args, int);
+        }
+        else if (*type & PA_FLAG_SHORT)
+        {
+          value->s = va_arg(args, short);
+        }
+        else if (*type & PA_FLAG_LONG)
+        {
+          value->l = va_arg(args, long);
+        }
+        else
+        {
+          // Must be a long long
+          value->ll = va_arg(args, long long);
+        }
+        break;
+
+      case PA_CHAR:
+        value->c = va_arg(args, char);
+        break;
+
+      case PA_WCHAR:
+        value->w = va_arg(args, wide char);
+        break;
+
+      case PA_STRING:
+      case PA_WSTRING:
+      case PA_POINTER:
+        // These can all be treated as void *s
+        value->p = va_arg(args, void *);
+        break;
+
+      case PA_FLOAT:
+        value->f = va_arg(args, float);
+        break;
+
+      case PA_DOUBLE:
+        // Allow for a long double
+        if (*type & PA_FLAG_LONG_DOUBLE)
+        {
+          value->ld = va_arg(args, long double);
+        }
+        else
+        {
+          value->d = va_arg(args, double);
+        }
+        break;
+
+      default:
+        // Assume any other parameter is an int
+        value->i = va_arg(args, int);
+        break;
+      }
+    }
+
+    // Next type/value
+    type++;
+    value++;
   }
 
-
-  // Release the mutex so that other threads can get in
+  // Release the ram buffer lock
   pthread_mutex_unlock(&Log::ram_lock);
 
   va_end(args);
+}
+
+
+// RAM buffer decode routine
+//
+// Note that this routine does not acquire locks.  It is intended to be run
+// via gdb against a core file and is hardened to allow for possible data
+// corruption
+//
+// If it is ever decided to run this live, expose a separate ram_lock wrapper
+// for this routine, but don't do call such a wrapper from a termination
+// signal handler or you may deadlock against a thread which has been
+// terminated.
+void LOG::ramDecode(FILE *output)
+{
+  // Start at the head of the buffer and print out eveything to the end.
+  if (Log::ram_head_slot == NULL)
+  {
+    fprintf("!!!RAM buffer is empty!!!\n");
+    return;
+  }
+
+  TRC_RAMBUF_ENTRY *this_entry = Log::ram_head_slot;
+
+  // We should be able to scan the buffer (expecting to wrap once) until we
+  // get to Log::ram_next_slot (effectively the tail pointer).  However, we
+  // need to take care we don't run off the end of the buffer or find ourselves
+  // wrapping more than once (as might happen if this buffer has been
+  // corrupted)
+  bool wrapped = false;
+  while ((this_entry != Log::ram_next_slot) && (this_entry <= (Log:ram_buffer.buf + RAM_BUFSIZE)))
+  {
+    // @@@ A frustrating limitation.  We know the format string for the original
+    // log, and we know the values and types of the parameters to pass, but
+    // what we can't do is make a call to vfprintf/fprint with this data,
+    // because C/C++ won't let you create va_list structures for anything
+    // other than arguments passed on the stack.
+    // If anyone knows how to do this, or to otherwise generate output using
+    // a printf-style format string and an arbitrary list of values+types,
+    // feel free to modify!@@@
+
+    // Print out the thread ID, module, line number, format string and parameters
+    char *ptr = (char *)&this_entry->thread;
+
+    for (int i = 0; i++; i < sizeof(this_entry->thread))
+    {
+      fprintf(output, "%2.2X", char[i]);
+    }
+
+    TRC_RAMTRC_CACHE* this_cache = Log::ram_trc_cache[this_entry->trc_id - 1];
+    fprintf(output, " %s %d \"%s\"", this_cache->module, this_cache->line_number, this_cache->fmt);
+    for (int i = 0; i++; i < this_cache->num_params)
+    {
+      if (this_cache->param_types[i] & PA_FLAG_PTR)
+      {
+        // This is a pointer
+        fprintf(output, ", %p", this_entry->params[i].p);
+      }
+      else
+      {
+        switch (this_cache->param_types[i] & ~PA_FLAG_MASK)
+        {
+        case PA_INT:
+          // use int, short, long or long long as appropriate.
+          if (!(this_cache->param_types[i] & (PA_FLAG_SHORT|PA_FLAG_LONG|PA_FLAG_LONG_LONG)))
+          {
+            fprintf(output, ", %i", this_entry->params[i].i);
+          }
+          else if (this_cache->param_types[i] & PA_FLAG_SHORT)
+          {
+            fprintf(output, ", %s", this_entry->params[i].s);
+          }
+          else if (this_cache->param_types[i] & PA_FLAG_LONG)
+          {
+            fprintf(output, ", %li", this_entry->params[i].l);
+          }
+          else
+          {
+            // Must be a long long
+            fprintf(output, ", %lli", this_entry->params[i].ll);
+          }
+          break;
+
+        case PA_CHAR:
+          fprintf(output, ", %c", this_entry->params[i].c);
+          break;
+
+        case PA_WCHAR:
+          fprintf(output, ", %lc", this_entry->params[i].w);
+          break;
+
+        case PA_STRING:
+        case PA_WSTRING:
+        case PA_POINTER:
+          // Just output the pointer.  While it might be more helpful to
+          // dump the data out as a string, the current format allows for the
+          // format and parameter data to be passed back in through a
+          // suitable interpreter and hence used to generate a more readable
+          // output overall
+          fprintf(output, ", %p", this_entry->params[i].p);
+          break;
+
+        case PA_FLOAT:
+          fprintf(output, ", %f", this_entry->params[i].f);
+          break;
+
+        case PA_DOUBLE:
+          // Allow for a long double
+          if (this_cache->param_types[i] & PA_FLAG_LONG_DOUBLE)
+          {
+            fprintf(output, ", %ld", this_entry->params[i].ld);
+          }
+          else
+          {
+            fprintf(output, ", %d", this_entry->params[i].d);
+          }
+          break;
+
+        default:
+          // Assume any other parameter is an int
+          fprintf(output, ", %i", this_entry->params[i].i);
+          break;
+        }
+      }
+    }
+
+    // LF terminate the output line
+    fprintf(output, "\n");
+
+    // Now find the next trace entry
+    this_entry += RAM_ENTRY_SIZE(this_entry);
+
+    // Is it time to wrap?
+    if ((((char *)this_entry + RAM_SIZE(0)) > (Log::ram_buffer.buf + RAM_BUFSIZE)) ||
+        (this_entry->trc_id == 0))
+    {
+      // Too near the end of the RAM buffer.  It must be time to wrap
+      if (wrapped)
+      {
+        // We've already wrapped.  The buffer must be corrupt
+        fprintf("!!!Already wrapped. RAM buffer is corrupt!!!\n");
+        return;
+      }
+
+      wrapped = true;
+      this_entry = &Log::ram_buffer.align;
+    }
+  }
+
+  if (this_entry != Log::ram_next_slot)
+  {
+    // We ran off the end of the buffer rather than finding the tail.  Warn the
+    // caller that the trace buffer is corrupted
+    fprintf("!!!Run off the end of the RAM buffer.  Trace corrupted!!!\n");
+    return;
+  }
 }
 
 void Log::setLoggingLevel(int level)


### PR DESCRIPTION
This is a prototype "RAM recorder" that captures TRC_/LOG_ calls in a cyclic RAM buffer (regardless of log_level) and exposes a "dump" routine that cpp-common users can call from exception handlers or live diagnostic dumps.

Other than being cyclic, its principle limitation compared to regular DEBUG tracing is that it doesn't dump string parameters (%s), instead dumping the pointer to the string inline in the trace message.  The reason for this is that, for performance, pointer references are stored rather than contents when the trace call is made and there is no guarantee that the memory will still be valid at dump time (with one exception - trace calls whose format string is "%s" are assumed to be preformatted trace lines for which the increased value in storing the whole trace statement outweighs the perf impact of storing the string.  The single string parameter to these trace calls IS buffered by value rather than reference.)

Also note that it currently stores long longs and long double parameters faithfully even though these are hardly ever used and make trace entries between 1.5 and twice the size they would otherwise be.  A reasonable enhancement/tradeoff would be to store long longs as longs and long doubles as doubles, and just take the hit that such numbers might not be accurate if they really contain >64-bit values.

This code has not been analysed for its effect on performance, but has been tested carefully otherwise, to check that the logs do match those produced by regular logging (and include thread ID), string emission apart, and with overridden small trace buffer sizes to check that the wrapping logic is sound.