### PR TITLE
Fix corrupted bodies on HTTP requests

### DIFF
--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -285,7 +285,10 @@ private:
                                    std::string uuid_str);
 
   /// Helper function that sets the general curl options in send_request
-  void set_curl_options_general(CURL* curl, std::string body, std::string& doc);
+  ///
+  /// @param body Body to send. This must survive until the request has been
+  /// sent
+  void set_curl_options_general(CURL* curl, std::string& body, std::string& doc);
 
   /// Helper function that sets response header curl options, if required, in
   /// send_request

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -750,7 +750,7 @@ struct curl_slist* HttpClient::build_headers(std::vector<std::string> headers_to
 }
 
 void HttpClient::set_curl_options_general(CURL* curl,
-                                          std::string body,
+                                          std::string& body,
                                           std::string& doc)
 {
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &doc);


### PR DESCRIPTION
Pass the body in by reference instead of by copy. The body needs to survive
until the request has been performed, as CURL's POSTFIELDS option takes a
reference to the underlying char array.